### PR TITLE
[Error Fixing] SyntaxError: Non-ASCII character '\xd0'

### DIFF
--- a/dist/html_connector.py
+++ b/dist/html_connector.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 from .html_translator import superTranslator, massTranslator, setProxy
 
 import re

--- a/dist/html_translator.py
+++ b/dist/html_translator.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 # from googletrans import Translator
 # from py_translator import Translator
 from .client import Translator


### PR DESCRIPTION
Description:
python --version
Python 2.7.12

I can't found lib py_translator in my pip package, so I clone this library from github and put it on my python library manually.
my python script needs this library work as well.

Error:
SyntaxError: Non-ASCII character '\xd0' in file /usr/local/lib/python2.7/dist-packages/py_translator/html_translator.py on line 31, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details

Solving:
http://python.org/dev/peps/pep-0263/ 